### PR TITLE
Replace papers with participation

### DIFF
--- a/djangocon_2020/content/talks/cfp/0cfp.md
+++ b/djangocon_2020/content/talks/cfp/0cfp.md
@@ -1,4 +1,4 @@
-title: call for papers
+title: call for participation
 layout: simple
 
 This page contains all information regarding the proposal process for DjangoCon Europe – we will update it regularly as new information becomes available.


### PR DESCRIPTION
I think that for someone who hasn't been at a DjangoCon before, saying "papers" can make matters quite confusing, because there are other types of conferences (academic ones) where people write very long articles and submit them.